### PR TITLE
ie8 compatibility

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -199,7 +199,11 @@ function reject(promise, reason){
 }
 
 function publish(promise) {
-  promise.then_ = promise.then_.forEach(invokeCallback);
+  for (var i = 0; i < promise.then_.length; i++) {
+    invokeCallback(promise.then_[i]);
+  }
+
+  promise.then_ = undefined;
 }
 
 function publishFulfillment(promise){
@@ -264,7 +268,7 @@ Promise.prototype = {
 Promise.all = function(promises){
   var Class = this;
 
-  if (!Array.isArray(promises))
+  if (Object.prototype.toString.call(promises) !== "[object Array]")
     throw new TypeError('You must pass an array to Promise.all().');
 
   return new Class(function(resolve, reject){
@@ -298,7 +302,7 @@ Promise.all = function(promises){
 Promise.race = function(promises){
   var Class = this;
 
-  if (!Array.isArray(promises))
+  if (Object.prototype.toString.call(promises) !== "[object Array]")
     throw new TypeError('You must pass an array to Promise.race().');
 
   return new Class(function(resolve, reject) {


### PR DESCRIPTION
This polyfill didn't work in ie8.

Array.forEach and Array.isArray are now replaced by IE8 compatible functions.
(https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Compatibility)

Please rebuild the min.js file. I don't know which tool you are using.