### PR TITLE
Add AMD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ var Promise = require('es6-promise-polyfill').Promise;
 var promise = new Promise(...);
 ```
 
+### AMD
+
+To install:
+
+```sh
+npm install es6-promise-polyfill
+```
+
+To use:
+
+```js
+define(['es6-promise-polyfill'], function(promise_polyfill) {
+  var Promise = PromisePolyfill.Promise;
+  var promise = new Promise(...);
+});
+```
+
+
 ## Usage in IE<9
 
 `catch` is a reserved word in IE<9, meaning `promise.catch(func)` throws a syntax error. To work around this, use a string to access the property:

--- a/promise.js
+++ b/promise.js
@@ -25,8 +25,16 @@ var nativePromiseSupported =
 //
 // export if necessary
 //
-
-if (typeof exports !== 'undefined' && exports)
+if (typeof define === 'function' && define.amd)
+{
+    define(function() {
+	return {
+	    Promise: nativePromiseSupported ? NativePromise : Promise,
+	    Polyfill: Promise
+	};
+    });
+}
+else if (typeof exports !== 'undefined' && exports)
 {
   // node.js
   exports.Promise = nativePromiseSupported ? NativePromise : Promise;


### PR DESCRIPTION
Add support for using es6-promise-polyfill as a AMD module.

Note: I couldn't create a new promise.min.js because there are no instructions on how to do so (See #7).