### PR TITLE
Amd fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ To use:
 var Promise = require('es6-promise-polyfill').Promise;
 var promise = new Promise(...);
 ```
+### AMD
+
+To install:
+
+```sh
+npm install es6-promise-polyfill
+```
+
+To use:
+
+```js
+define['es6-promise-polyfill'], function(promise_polyfill) {
+var Promise = promise_polyfill.Promise;
+var promise = new Promise(...);
+```
 
 ## Usage in IE<9
 

--- a/promise.js
+++ b/promise.js
@@ -23,34 +23,6 @@ var nativePromiseSupported =
 
 
 //
-// export if necessary
-//
-
-if (typeof exports !== 'undefined' && exports)
-{
-  // node.js
-  exports.Promise = nativePromiseSupported ? NativePromise : Promise;
-  exports.Polyfill = Promise;
-}
-else
-{
-  // AMD
-  if (typeof define == 'function' && define.amd)
-  {
-    define(function(){
-      return nativePromiseSupported ? NativePromise : Promise;
-    });
-  }
-  else
-  {
-    // in browser add to global
-    if (!nativePromiseSupported)
-      global['Promise'] = Promise;
-  }
-}
-
-
-//
 // Polyfill
 //
 
@@ -342,5 +314,35 @@ Promise.reject = function(reason){
     reject(reason);
   });
 };
+
+//
+// export if necessary
+//
+
+if (typeof exports !== 'undefined' && exports)
+{
+  // node.js
+  exports.Promise = nativePromiseSupported ? NativePromise : Promise;
+  exports.Polyfill = Promise;
+}
+else
+{
+  // AMD
+  if (typeof define == 'function' && define.amd)
+  {
+    define(function(){
+	return {
+	    Promise: nativePromiseSupported ? NativePromise : Promise,
+	    Polyfill: Promise
+	};
+    });
+  }
+  else
+  {
+    // in browser add to global
+    if (!nativePromiseSupported)
+      global['Promise'] = Promise;
+  }
+}
 
 })(typeof window != 'undefined' ? window : typeof global != 'undefined' ? global : typeof self != 'undefined' ? self : this);


### PR DESCRIPTION
UMD pattern doesn't work correctly with AMD modules because the values are exported before initialized correctly. These commits do the following things:

* Move UMD pattern to the bottom of the function so that the exported values have all properties available
* Return the same object for both Node.js require and AMD. Previously only the native Promise/Polyfill was returned for AMD.
* Add usage instructions for AMD.